### PR TITLE
Bad decodes

### DIFF
--- a/src/main/scala/com/twitter/gizzard/scheduler/JobScheduler.scala
+++ b/src/main/scala/com/twitter/gizzard/scheduler/JobScheduler.scala
@@ -190,7 +190,13 @@ class JobScheduler[J <: Job](val name: String,
   }
 
   def process() {
-    queue.get().foreach { ticket =>
+    (try {
+      queue.get()
+    } catch {
+      case e: Exception =>
+        log.error(e, "Unable to parse job")
+        None
+    }).foreach { ticket =>
       val job = ticket.job
       try {
         job()

--- a/src/test/scala/com/twitter/gizzard/scheduler_new/JobSchedulerSpec.scala
+++ b/src/test/scala/com/twitter/gizzard/scheduler_new/JobSchedulerSpec.scala
@@ -216,6 +216,14 @@ class JobSchedulerSpec extends ConfiguredSpecification with JMocker with ClassMo
 
         jobScheduler.process()
       }
+
+      "decoder error" in {
+        expect {
+          one(queue).get() willThrow new UnparsableJsonException("Unparsable json", null)
+        }
+
+        jobScheduler.process()
+      }
     }
   }
 }


### PR DESCRIPTION
if a queue item can't be decoded, confirm the remove (so you don't try again later), log an error, and move on.
