### PR TITLE
Make creation of ExceptionHandlingProxy instances more efficient

### DIFF
--- a/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
+++ b/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
@@ -8,9 +8,10 @@ import com.twitter.querulous.database.SqlDatabaseTimeoutException
 import com.twitter.querulous.query.SqlQueryTimeoutException
 
 
-class ExceptionHandlingProxy(f: Throwable => Unit) {
-  def apply[T <: AnyRef](obj: T)(implicit manifest: Manifest[T]): T = {
-    Proxy(obj) { method =>
+class ExceptionHandlingProxy[T <: AnyRef](f: Throwable => Unit)(implicit manifest: Manifest[T]) {
+  val proxyFactory = new ProxyFactory[T]
+  def apply(obj: T): T = {
+    proxyFactory(obj) { method =>
       try {
         method()
       } catch {


### PR DESCRIPTION
Profiling Haplo has shown that 5.4% of CPU was spent by Gizzard creating reflection proxies for wrapping RedisShard instances into an ExceptionHandlingProxy. Of that, 5.1% is spent in repetitive operations and can be reclaimed by memoizing the constructor for the proxy class.
