### PR TITLE
Type-bound proxy factories, take 2

### DIFF
--- a/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
+++ b/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
@@ -22,8 +22,26 @@ class ExceptionHandlingProxy(f: Throwable => Unit) {
   }
 }
 
+/**
+ * A factory for type-bound exception-handling proxies. It creates proxies for
+ * a specific class. It has much better runtime performance (about 30x on 
+ * current hardware and JVM) when creating proxies than ExceptionHandlingProxy
+ * does, as it memoizes the expensive class-specific lookup.
+ * @tparam T the type of the objects that will be proxied
+ * @param f the exception handling function
+ * @author Attila Szegedi
+ */
 class ExceptionHandlingProxyFactory[T <: AnyRef](f: Throwable => Unit)(implicit manifest: Manifest[T]) {
   val proxyFactory = new ProxyFactory[T]
+  /**
+   * Creates an exception-handling proxy for the specific object where each 
+   * method call on the proxy is wrapped in an exception handler.
+   * @param obj the object being proxied
+   * @tparam I the exposed interface of the created proxy. Must be an 
+   * interface the object implements.
+   * @return a proxy for the object, implementing the requested interface, 
+   * that has each of its method invocations wrapped in an exception handler.
+   */
   def apply[I >: T](obj: T): I = {
     proxyFactory(obj) { method =>
       try {

--- a/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
+++ b/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
@@ -8,9 +8,10 @@ import com.twitter.querulous.database.SqlDatabaseTimeoutException
 import com.twitter.querulous.query.SqlQueryTimeoutException
 
 
-class ExceptionHandlingProxy(f: Throwable => Unit) {
-  def apply[T <: AnyRef](obj: T)(implicit manifest: Manifest[T]): T = {
-    Proxy(obj) { method =>
+class ExceptionHandlingProxy[T <: AnyRef](f: Throwable => Unit)(implicit manifest: Manifest[T]) {
+  val proxyFactory = new ProxyFactory[T]
+  def apply(obj: T): T = {
+    proxyFactory(obj) { method =>
       try {
         method()
       } catch {

--- a/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
+++ b/src/main/scala/com/twitter/gizzard/proxy/ExceptionHandlingProxy.scala
@@ -24,7 +24,7 @@ class ExceptionHandlingProxy(f: Throwable => Unit) {
 
 class ExceptionHandlingProxyFactory[T <: AnyRef](f: Throwable => Unit)(implicit manifest: Manifest[T]) {
   val proxyFactory = new ProxyFactory[T]
-  def apply(obj: T): T = {
+  def apply[I >: T](obj: T): I = {
     proxyFactory(obj) { method =>
       try {
         method()

--- a/src/main/scala/com/twitter/gizzard/proxy/Proxy.scala
+++ b/src/main/scala/com/twitter/gizzard/proxy/Proxy.scala
@@ -66,13 +66,13 @@ class ProxyFactory[T <: AnyRef](implicit manifest: Manifest[T]) {
     clazz.getConstructor(classOf[reflect.InvocationHandler])
   }
 
-  def apply(obj: T)(f: Proxy.MethodCall[T] => Object): T = {
+  def apply[I >: T](obj: T)(f: Proxy.MethodCall[T] => Object): I = {
     val invocationHandler = new reflect.InvocationHandler {
       def invoke(unused: Object, method: reflect.Method, args: Array[Object]) = {
         f(new Proxy.MethodCall(obj, method, args))
       }
     }
 
-    ctor.newInstance(invocationHandler).asInstanceOf[T]
+    ctor.newInstance(invocationHandler).asInstanceOf[I]
   }
 }

--- a/src/main/scala/com/twitter/gizzard/proxy/Proxy.scala
+++ b/src/main/scala/com/twitter/gizzard/proxy/Proxy.scala
@@ -57,6 +57,14 @@ object Proxy {
   }
 }
 
+/**
+ * A factory for type-bound proxies. It creates proxies for a specific class.
+ * It has much better runtime performance (about 30x on current hardware and 
+ * JVM) when creating proxies than Proxy does, as it memoizes the expensive 
+ * class-specific lookup.
+ * @tparam T the type of the objects that will be proxied
+ * @author Attila Szegedi
+ */
 class ProxyFactory[T <: AnyRef](implicit manifest: Manifest[T]) {
   val ctor = getProxyConstructor(manifest)
 
@@ -66,6 +74,16 @@ class ProxyFactory[T <: AnyRef](implicit manifest: Manifest[T]) {
     clazz.getConstructor(classOf[reflect.InvocationHandler])
   }
 
+  /**
+   * Creates a proxy for the specific object where each method call on the 
+   * proxy is sent to the specified function.
+   * @param obj the object being proxied
+   * @param f the function receiving each method call
+   * @tparam I the exposed interface of the created proxy. Must be an 
+   * interface the object implements.
+   * @return a proxy for the object, implementing the requested interface, 
+   * that sends each method invocation through the specified function.
+   */
   def apply[I >: T](obj: T)(f: Proxy.MethodCall[T] => Object): I = {
     val invocationHandler = new reflect.InvocationHandler {
       def invoke(unused: Object, method: reflect.Method, args: Array[Object]) = {


### PR DESCRIPTION
Had to fix a discrepancy between the type of the object being proxied, and the fact that the generated proxies aren't instances of it, but only implement its interfaces. Haplo tests pass now with this (they didn't before).
