### PR TITLE
Nameserver batch api

### DIFF
--- a/src/main/scala/com/twitter/gizzard/nameserver/BatchedCommand.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/BatchedCommand.scala
@@ -1,0 +1,35 @@
+package com.twitter.gizzard.nameserver
+
+import com.twitter.gizzard.thrift.{BatchedCommand => ThriftBatchedCommand}
+import com.twitter.gizzard.thrift.BatchedCommand._Fields._
+import com.twitter.gizzard.thrift.conversions.Forwarding._
+import com.twitter.gizzard.thrift.conversions.ShardId._
+import com.twitter.gizzard.thrift.conversions.ShardInfo._
+import com.twitter.gizzard.shards.{ShardId, ShardInfo}
+
+sealed abstract class BatchedCommand
+case class CreateShard(shardInfo : ShardInfo) extends BatchedCommand
+case class DeleteShard(shardId : ShardId) extends BatchedCommand
+case class AddLink(upId : ShardId, downId : ShardId, weight : Int) extends BatchedCommand
+case class RemoveLink(upId : ShardId, downId : ShardId) extends BatchedCommand
+case class SetForwarding(forwarding : Forwarding) extends BatchedCommand
+case class RemoveForwarding(forwarding : Forwarding) extends BatchedCommand
+
+object BatchedCommand {
+  def apply(thriftCommand : ThriftBatchedCommand) : BatchedCommand = {
+    thriftCommand.getSetField() match {
+      case CREATE_SHARD => CreateShard(thriftCommand.getCreate_shard().fromThrift)
+      case DELETE_SHARD => DeleteShard(thriftCommand.getDelete_shard().fromThrift)
+      case ADD_LINK => {
+        val addLink = thriftCommand.getAdd_link()
+        AddLink(addLink.getUp_id().fromThrift, addLink.getDown_id().fromThrift, addLink.getWeight())
+      }
+      case REMOVE_LINK => {
+        val removeLink = thriftCommand.getRemove_link()
+        RemoveLink(removeLink.getUp_id().fromThrift, removeLink.getDown_id().fromThrift)
+      }
+      case SET_FORWARDING => SetForwarding(thriftCommand.getSet_forwarding().fromThrift)
+      case REMOVE_FORWARDING => RemoveForwarding(thriftCommand.getRemove_forwarding().fromThrift)
+    }
+  }
+}

--- a/src/main/scala/com/twitter/gizzard/nameserver/MemoryShard.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/MemoryShard.scala
@@ -8,6 +8,8 @@ import com.twitter.gizzard.shards._
 /**
  * NameServer implementation that doesn't actually store anything anywhere.
  * Useful for tests or stubbing out the partitioning scheme.
+ *
+ * Note: batch_execute commands are not executed atomically in this implementation.
  */
 class MemoryShardManagerSource extends ShardManagerSource {
 
@@ -158,6 +160,19 @@ class MemoryShardManagerSource extends ShardManagerSource {
 
   def incrementVersion() {
     updateVersion.incrementAndGet()
+  }
+
+  def batchExecute(commands : Seq[BatchedCommand]) {
+    for (cmd <- commands) {
+      cmd match {
+        case CreateShard(shardInfo) => createShard(shardInfo)
+        case DeleteShard(shardId) => deleteShard(shardId)
+        case AddLink(upId, downId, weight) => addLink(upId, downId, weight)
+        case RemoveLink(upId, downId) => removeLink(upId, downId)
+        case SetForwarding(forwarding) => setForwarding(forwarding)
+        case RemoveForwarding(forwarding) => removeForwarding(forwarding)
+      }
+    }
   }
 
   def reload() { }

--- a/src/main/scala/com/twitter/gizzard/nameserver/MemoryShard.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/MemoryShard.scala
@@ -16,7 +16,7 @@ class MemoryShardManagerSource extends ShardManagerSource {
   val shardTable = new mutable.ListBuffer[ShardInfo]()
   val parentTable = new mutable.ListBuffer[LinkInfo]()
   val forwardingTable = new mutable.ListBuffer[Forwarding]()
-  val updateVersion = new AtomicLong(0L)
+  val stateVersion = new AtomicLong(0L)
 
   private def find(info: ShardInfo): Option[ShardInfo] = {
     shardTable.find { x =>
@@ -156,10 +156,12 @@ class MemoryShardManagerSource extends ShardManagerSource {
     forwardingTable.map(_.tableId).toSet.toSeq.sortWith((a,b) => a < b)
   }
 
-  def getUpdateVersion() : Long = updateVersion.get()
+  def getCurrentStateVersion() : Long = stateVersion.get()
 
-  def incrementVersion() {
-    updateVersion.incrementAndGet()
+  def getMasterStateVersion() : Long = stateVersion.get()
+
+  def incrementStateVersion() {
+    stateVersion.incrementAndGet()
   }
 
   def batchExecute(commands : Seq[BatchedCommand]) {

--- a/src/main/scala/com/twitter/gizzard/nameserver/MemoryShard.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/MemoryShard.scala
@@ -1,5 +1,6 @@
 package com.twitter.gizzard.nameserver
 
+import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable
 import com.twitter.gizzard.shards._
 
@@ -13,6 +14,7 @@ class MemoryShardManagerSource extends ShardManagerSource {
   val shardTable = new mutable.ListBuffer[ShardInfo]()
   val parentTable = new mutable.ListBuffer[LinkInfo]()
   val forwardingTable = new mutable.ListBuffer[Forwarding]()
+  val updateVersion = new AtomicLong(0L)
 
   private def find(info: ShardInfo): Option[ShardInfo] = {
     shardTable.find { x =>
@@ -150,6 +152,12 @@ class MemoryShardManagerSource extends ShardManagerSource {
 
   def listTables(): Seq[Int] = {
     forwardingTable.map(_.tableId).toSet.toSeq.sortWith((a,b) => a < b)
+  }
+
+  def getUpdateVersion() : Long = updateVersion.get()
+
+  def incrementVersion() {
+    updateVersion.incrementAndGet()
   }
 
   def reload() { }

--- a/src/main/scala/com/twitter/gizzard/nameserver/PollingUpdater.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/PollingUpdater.scala
@@ -1,0 +1,54 @@
+package com.twitter.gizzard.nameserver
+
+import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.twitter.logging.Logger
+import com.twitter.util.Duration
+
+class PollingUpdater(nameServer : NameServer, pollInterval : Duration) {
+  private val log = Logger.get(getClass.getName)
+  private val threadFactory = new ThreadFactoryBuilder().setDaemon(true).
+      setNameFormat("gizzard-polling-updater-%d").build()
+  private val scheduledExecutor = Executors.newScheduledThreadPool(1, threadFactory)
+  @volatile private var lastVersion = 0L
+
+  private[nameserver] def poll() {
+    val currentVersion = try {
+      nameServer.shardManager.getUpdateVersion()
+    } catch {
+      case e: Exception => {
+        log.error(e, "[PollingUpdater] failed to read version from name server")
+        lastVersion
+      }
+    }
+    log.ifDebug("[PollingUpdater] current version %d".format(currentVersion))
+    if (currentVersion > lastVersion) {
+      log.info("[PollingUpdater] detected version change. Old version: %d. New version %d. Reloading config",
+               lastVersion, currentVersion)
+      lastVersion = currentVersion
+      try {
+        nameServer.reload()
+      } catch {
+        case e: Exception =>
+          log.error(e, "[PollingUpdater] exception while reloading config")
+      }
+    }
+  }
+
+  def start() {
+    log.info("[PollingUpdater] starting. Poll interval: %s", pollInterval)
+    lastVersion = nameServer.shardManager.getUpdateVersion()
+    log.info("[PollingUpdater] initial version %d", lastVersion)
+    val intervalSec = pollInterval.inSeconds
+    val pollTask = new Runnable() {
+      override def run() {
+        poll()
+      }
+    }
+    scheduledExecutor.scheduleWithFixedDelay(pollTask, 0L, intervalSec, TimeUnit.SECONDS)
+  }
+
+  def stop() {
+    scheduledExecutor.shutdown()
+  }
+}

--- a/src/main/scala/com/twitter/gizzard/nameserver/PollingUpdater.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/PollingUpdater.scala
@@ -10,35 +10,36 @@ class PollingUpdater(nameServer : NameServer, pollInterval : Duration) {
   private val threadFactory = new ThreadFactoryBuilder().setDaemon(true).
       setNameFormat("gizzard-polling-updater-%d").build()
   private val scheduledExecutor = Executors.newScheduledThreadPool(1, threadFactory)
-  @volatile private var lastVersion = 0L
 
   private[nameserver] def poll() {
-    val currentVersion = try {
-      nameServer.shardManager.getUpdateVersion()
+    val (currentVersion, masterVersion) = try {
+      (nameServer.shardManager.getCurrentStateVersion(),
+      nameServer.shardManager.getMasterStateVersion())
     } catch {
       case e: Exception => {
-        log.error(e, "[PollingUpdater] failed to read version from name server")
-        lastVersion
+        log.error(e, "[PollingUpdater] failed to read state version from name server")
+        return
       }
     }
-    log.ifDebug("[PollingUpdater] current version %d".format(currentVersion))
-    if (currentVersion > lastVersion) {
+    log.ifDebug("[PollingUpdater] current version: %d, master version: %d".
+        format(currentVersion, masterVersion))
+    if (currentVersion < masterVersion) {
       log.info("[PollingUpdater] detected version change. Old version: %d. New version %d. Reloading config",
-               lastVersion, currentVersion)
-      lastVersion = currentVersion
+               currentVersion)
       try {
         nameServer.reload()
       } catch {
         case e: Exception =>
           log.error(e, "[PollingUpdater] exception while reloading config")
       }
+    } else if (currentVersion > masterVersion) {
+      log.critical("[PollingUpdater] current version %d is greater than master version %d".
+          format(currentVersion, masterVersion))
     }
   }
 
   def start() {
     log.info("[PollingUpdater] starting. Poll interval: %s", pollInterval)
-    lastVersion = nameServer.shardManager.getUpdateVersion()
-    log.info("[PollingUpdater] initial version %d", lastVersion)
     val intervalSec = pollInterval.inSeconds
     val pollTask = new Runnable() {
       override def run() {

--- a/src/main/scala/com/twitter/gizzard/nameserver/ShardManager.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/ShardManager.scala
@@ -46,8 +46,9 @@ class ShardManager(shard: RoutingNode[ShardManagerSource], repo: ShardRepository
   def listHostnames() = shard.read.any(_.listHostnames())
   def listTables()    = shard.read.any(_.listTables())
 
-  def getUpdateVersion() = shard.read.any(_.getUpdateVersion())
-  def incrementVersion() { shard.write.foreach(_.incrementVersion()) }
+  def incrementStateVersion() { shard.write.foreach(_.incrementStateVersion()) }
+  def getCurrentStateVersion() = shard.read.any(_.getCurrentStateVersion())
+  def getMasterStateVersion() = shard.read.any(_.getMasterStateVersion())
 
   def batchExecute(commands : Seq[BatchedCommand]) { shard.write.foreach(_.batchExecute(commands)) }
 }
@@ -96,8 +97,9 @@ trait ShardManagerSource {
   @throws(classOf[ShardException]) def listHostnames(): Seq[String]
   @throws(classOf[ShardException]) def listTables(): Seq[Int]
 
-  @throws(classOf[ShardException]) def getUpdateVersion() : Long
-  @throws(classOf[ShardException]) def incrementVersion()
+  @throws(classOf[ShardException]) def getCurrentStateVersion() : Long
+  @throws(classOf[ShardException]) def getMasterStateVersion() : Long
+  @throws(classOf[ShardException]) def incrementStateVersion()
 
   @throws(classOf[ShardException]) def batchExecute(commands : Seq[BatchedCommand])
 }

--- a/src/main/scala/com/twitter/gizzard/nameserver/ShardManager.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/ShardManager.scala
@@ -48,6 +48,8 @@ class ShardManager(shard: RoutingNode[ShardManagerSource], repo: ShardRepository
 
   def getUpdateVersion() = shard.read.any(_.getUpdateVersion())
   def incrementVersion() { shard.write.foreach(_.incrementVersion()) }
+
+  def batchExecute(commands : Seq[BatchedCommand]) { shard.write.foreach(_.batchExecute(commands)) }
 }
 
 trait ShardManagerSource {
@@ -96,4 +98,6 @@ trait ShardManagerSource {
 
   @throws(classOf[ShardException]) def getUpdateVersion() : Long
   @throws(classOf[ShardException]) def incrementVersion()
+
+  @throws(classOf[ShardException]) def batchExecute(commands : Seq[BatchedCommand])
 }

--- a/src/main/scala/com/twitter/gizzard/nameserver/ShardManager.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/ShardManager.scala
@@ -43,9 +43,11 @@ class ShardManager(shard: RoutingNode[ShardManagerSource], repo: ShardRepository
   def getForwardingForShard(id: ShardId)        = shard.read.any(_.getForwardingForShard(id))
   def getForwardings()                          = shard.read.any(_.getForwardings())
 
-
   def listHostnames() = shard.read.any(_.listHostnames())
   def listTables()    = shard.read.any(_.listTables())
+
+  def getUpdateVersion() = shard.read.any(_.getUpdateVersion())
+  def incrementVersion() { shard.write.foreach(_.incrementVersion()) }
 }
 
 trait ShardManagerSource {
@@ -91,4 +93,7 @@ trait ShardManagerSource {
 
   @throws(classOf[ShardException]) def listHostnames(): Seq[String]
   @throws(classOf[ShardException]) def listTables(): Seq[Int]
+
+  @throws(classOf[ShardException]) def getUpdateVersion() : Long
+  @throws(classOf[ShardException]) def incrementVersion()
 }

--- a/src/main/scala/com/twitter/gizzard/nameserver/SqlShard.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/SqlShard.scala
@@ -2,7 +2,8 @@ package com.twitter.gizzard.nameserver
 
 import java.sql.{ResultSet, SQLException, SQLIntegrityConstraintViolationException}
 import scala.collection.mutable
-import com.twitter.querulous.evaluator.QueryEvaluator
+import com.twitter.logging.Logger
+import com.twitter.querulous.evaluator.{QueryEvaluator, Transaction}
 import com.twitter.gizzard.util.TreeUtils
 import com.twitter.gizzard.shards._
 
@@ -69,45 +70,41 @@ CREATE TABLE IF NOT EXISTS hosts (
     INDEX cluster (cluster, status)
 ) ENGINE=INNODB;
 """
-}
 
-
-class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManagerSource {
-
-  private def rowToShardInfo(row: ResultSet) = {
+  def rowToShardInfo(row: ResultSet) = {
     ShardInfo(ShardId(row.getString("hostname"), row.getString("table_prefix")), row.getString("class_name"),
       row.getString("source_type"), row.getString("destination_type"), Busy(row.getInt("busy")))
   }
 
-  private def rowToForwarding(row: ResultSet) = {
+  def rowToForwarding(row: ResultSet) = {
     Forwarding(row.getInt("table_id"), row.getLong("base_source_id"), ShardId(row.getString("shard_hostname"), row.getString("shard_table_prefix")))
   }
 
-  private def rowToLinkInfo(row: ResultSet) = {
+  def rowToLinkInfo(row: ResultSet) = {
     LinkInfo(ShardId(row.getString("parent_hostname"), row.getString("parent_table_prefix")),
              ShardId(row.getString("child_hostname"), row.getString("child_table_prefix")),
              row.getInt("weight"))
   }
+}
 
 
+class SqlShardManagerTransaction(transaction : Transaction) extends ShardManagerSource {
   // Forwardings/Shard Management Write Methods
 
   def createShard(shardInfo: ShardInfo) {
     try {
-      queryEvaluator.transaction { transaction =>
-        transaction.selectOne("SELECT * FROM shards WHERE table_prefix = ? AND hostname = ?",
-                              shardInfo.tablePrefix, shardInfo.hostname) { row =>
-          if (row.getString("class_name") != shardInfo.className ||
-              row.getString("source_type") != shardInfo.sourceType ||
-              row.getString("destination_type") != shardInfo.destinationType) {
-            throw new InvalidShard("Invalid shard: %s doesn't match %s".format(rowToShardInfo(row), shardInfo))
-          }
-        } getOrElse {
-          transaction.insert("INSERT INTO shards (hostname, table_prefix, class_name, " +
-                             "source_type, destination_type) VALUES (?, ?, ?, ?, ?)",
-                             shardInfo.hostname, shardInfo.tablePrefix, shardInfo.className,
-                             shardInfo.sourceType, shardInfo.destinationType)
+      transaction.selectOne("SELECT * FROM shards WHERE table_prefix = ? AND hostname = ?",
+                            shardInfo.tablePrefix, shardInfo.hostname) { row =>
+        if (row.getString("class_name") != shardInfo.className ||
+            row.getString("source_type") != shardInfo.sourceType ||
+            row.getString("destination_type") != shardInfo.destinationType) {
+          throw new InvalidShard("Invalid shard: %s doesn't match %s".format(SqlShard.rowToShardInfo(row), shardInfo))
         }
+      } getOrElse {
+        transaction.insert("INSERT INTO shards (hostname, table_prefix, class_name, " +
+                           "source_type, destination_type) VALUES (?, ?, ?, ?, ?)",
+                           shardInfo.hostname, shardInfo.tablePrefix, shardInfo.className,
+                           shardInfo.sourceType, shardInfo.destinationType)
       }
 
       markAncestorForwardingsAsUpdated(shardInfo.id)
@@ -124,7 +121,7 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
     if (listDownwardLinks(id).length > 0) {
       throw new ShardException("Shard still has links")
     }
-    queryEvaluator.execute("DELETE FROM shards WHERE hostname = ? AND table_prefix = ?", id.hostname, id.tablePrefix) == 0
+    transaction.execute("DELETE FROM shards WHERE hostname = ? AND table_prefix = ?", id.hostname, id.tablePrefix) == 0
 
     markAncestorForwardingsAsUpdated(id)
   }
@@ -136,7 +133,7 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
     // Links to non-existant shards are a bad thing
     getShard(upId)
     getShard(downId)
-    queryEvaluator.execute("INSERT INTO shard_children (parent_hostname, parent_table_prefix, child_hostname, child_table_prefix, weight) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE weight=VALUES(weight)",
+    transaction.execute("INSERT INTO shard_children (parent_hostname, parent_table_prefix, child_hostname, child_table_prefix, weight) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE weight=VALUES(weight)",
       upId.hostname, upId.tablePrefix, downId.hostname, downId.tablePrefix, weight)
     // XXX: todo - check loops
 
@@ -144,7 +141,7 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
   }
 
   def removeLink(upId: ShardId, downId: ShardId) {
-    queryEvaluator.execute("DELETE FROM shard_children WHERE parent_hostname = ? AND parent_table_prefix = ? AND child_hostname = ? AND child_table_prefix = ?",
+    transaction.execute("DELETE FROM shard_children WHERE parent_hostname = ? AND parent_table_prefix = ? AND child_hostname = ? AND child_table_prefix = ?",
       upId.hostname, upId.tablePrefix, downId.hostname, downId.tablePrefix) == 0
 
     Seq(upId, downId).foreach(markAncestorForwardingsAsUpdated)
@@ -165,19 +162,17 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
     }
   }
 
-  def setForwarding(f: Forwarding) { insertOrUpdateForwarding(queryEvaluator, f, false) }
+  def setForwarding(f: Forwarding) { insertOrUpdateForwarding(transaction, f, false) }
 
-  def removeForwarding(f: Forwarding) { insertOrUpdateForwarding(queryEvaluator, f, true) }
+  def removeForwarding(f: Forwarding) { insertOrUpdateForwarding(transaction, f, true) }
 
   def replaceForwarding(oldId: ShardId, newId: ShardId) {
     val query       = "SELECT * FROM forwardings WHERE shard_hostname = ? AND shard_table_prefix = ?"
 
-    queryEvaluator.transaction { t =>
-      val forwardings = t.select(query, oldId.hostname, oldId.tablePrefix)(rowToForwarding)
+    val forwardings = transaction.select(query, oldId.hostname, oldId.tablePrefix)(SqlShard.rowToForwarding)
 
-      forwardings.foreach { case Forwarding(tableId, baseId, _) =>
-        insertOrUpdateForwarding(t, Forwarding(tableId, baseId, newId), false)
-      }
+    forwardings.foreach { case Forwarding(tableId, baseId, _) =>
+      insertOrUpdateForwarding(transaction, Forwarding(tableId, baseId, newId), false)
     }
   }
 
@@ -189,6 +184,177 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
     ancestorIds.foreach(id => replaceForwarding(id, id))
   }
 
+
+  // Version methods
+  def getUpdateVersion() : Long = {
+    val query = "SELECT counter FROM update_counters WHERE id = 'version'"
+    transaction.selectOne(query)(_.getLong("counter")).getOrElse(0L)
+  }
+
+  def incrementVersion() {
+    transaction.execute(
+      "INSERT INTO update_counters (id, counter) VALUES ('version', 1) ON DUPLICATE KEY UPDATE counter = counter + 1")
+  }
+
+  def getShard(id: ShardId) = {
+    val query = "SELECT * FROM shards WHERE hostname = ? AND table_prefix = ?"
+    transaction.selectOne(query, id.hostname, id.tablePrefix)(SqlShard.rowToShardInfo) getOrElse {
+      throw new NonExistentShard("Shard not found: %s".format(id))
+    }
+  }
+
+  def listTables() = {
+    transaction.select("SELECT DISTINCT table_id FROM forwardings")(_.getInt("table_id")).toList.sortWith((a,b) => a < b)
+  }
+
+  def listHostnames() = {
+    transaction.select("SELECT DISTINCT hostname FROM shards")(_.getString("hostname")).toList
+  }
+
+  def listLinks() = {
+    transaction.select("SELECT * FROM shard_children ORDER BY parent_hostname, parent_table_prefix")(SqlShard.rowToLinkInfo).toList
+  }
+
+  def listDownwardLinks(id: ShardId) = {
+    val query = "SELECT * FROM shard_children WHERE parent_hostname = ? AND parent_table_prefix = ? ORDER BY weight DESC"
+    transaction.select(query, id.hostname, id.tablePrefix)(SqlShard.rowToLinkInfo).toList
+  }
+
+  def listUpwardLinks(id: ShardId) = {
+    val query = "SELECT * FROM shard_children WHERE child_hostname = ? AND child_table_prefix = ? ORDER BY weight DESC"
+    transaction.select(query, id.hostname, id.tablePrefix)(SqlShard.rowToLinkInfo).toList
+  }
+
+  def listShards() = {
+    transaction.select("SELECT * FROM shards")(SqlShard.rowToShardInfo).toList
+  }
+
+  def markShardBusy(id: ShardId, busy: Busy.Value) {
+    val query = "UPDATE shards SET busy = ? WHERE hostname = ? AND table_prefix = ?"
+    if (transaction.execute(query, busy.id, id.hostname, id.tablePrefix) == 0) {
+      throw new NonExistentShard("Could not find shard: %s".format(id))
+    }
+  }
+
+  def getForwarding(tableId: Int, baseId: Long) = {
+    val query = "SELECT * FROM forwardings WHERE base_source_id = ? AND table_id = ? AND deleted = 0"
+    transaction.selectOne(query, baseId, tableId)(SqlShard.rowToForwarding) getOrElse { throw new ShardException("No such forwarding") }
+  }
+
+  def getForwardingForShard(id: ShardId) = {
+    val query = "SELECT * FROM forwardings WHERE shard_hostname = ? AND shard_table_prefix = ? AND deleted = 0"
+    transaction.selectOne(query, id.hostname, id.tablePrefix)(SqlShard.rowToForwarding) getOrElse { throw new ShardException("No such forwarding") }
+  }
+
+  def getForwardings() = {
+    transaction.select("SELECT * FROM forwardings WHERE deleted = 0 ORDER BY table_id, base_source_id ASC")(SqlShard.rowToForwarding).toList
+  }
+
+  def getForwardingsForTableIds(tableIds: Seq[Int]) = {
+    transaction.select("SELECT * FROM forwardings WHERE table_id IN (?) AND deleted = 0 ORDER BY table_id, base_source_id ASC", tableIds)(SqlShard.rowToForwarding).toList
+  }
+
+  def shardsForHostname(hostname: String) = {
+    transaction.select("SELECT * FROM shards WHERE hostname = ?", hostname)(SqlShard.rowToShardInfo).toList
+  }
+
+  def getBusyShards() = {
+    transaction.select("SELECT * FROM shards where busy != 0")(SqlShard.rowToShardInfo).toList
+  }
+
+  def reload() {
+    throw new UnsupportedOperationException("reload not supported within a transactional context")
+  }
+
+  def currentState(): Seq[NameServerState] = {
+    throw new UnsupportedOperationException("shard state not supported within a transactional context")
+  }
+
+  def batchExecute(commands : Seq[BatchedCommand]) {
+    for (cmd <- commands) {
+      cmd match {
+        case CreateShard(shardInfo) => createShard(shardInfo)
+        case DeleteShard(shardId) => deleteShard(shardId)
+        case AddLink(upId, downId, weight) => addLink(upId, downId, weight)
+        case RemoveLink(upId, downId) => removeLink(upId, downId)
+        case SetForwarding(forwarding) => setForwarding(forwarding)
+        case RemoveForwarding(forwarding) => removeForwarding(forwarding)
+      }
+    }
+  }
+}
+
+class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManagerSource {
+  private val log = Logger.get(getClass.getName)
+
+  private def withTransaction [T] (f : ShardManagerSource => T) : T = {
+    queryEvaluator.transaction(t => f(new SqlShardManagerTransaction(t)))
+  }
+
+  def reload() {
+    try {
+      synchronized {
+        _currentState         = null
+        _forwardingUpdatedSeq = 0L
+      }
+
+      List("shards", "shard_children", "forwardings", "update_counters", "hosts").foreach { table =>
+        queryEvaluator.select("DESCRIBE " + table) { row => }
+      }
+    } catch {
+      case e: SQLException =>
+        // try creating the schema
+        rebuildSchema()
+    }
+  }
+
+  def rebuildSchema() {
+    queryEvaluator.execute(SqlShard.SHARDS_DDL)
+    queryEvaluator.execute(SqlShard.SHARD_CHILDREN_DDL)
+    queryEvaluator.execute(SqlShard.FORWARDINGS_DDL)
+    queryEvaluator.execute(SqlShard.UPDATE_COUNTER_DDL)
+  }
+
+  def createShard(shardInfo: ShardInfo) { withTransaction(_.createShard(shardInfo)) }
+  def deleteShard(id: ShardId) { withTransaction(_.deleteShard(id)) }
+  def markShardBusy(id: ShardId, busy: Busy.Value) { withTransaction(_.markShardBusy(id, busy)) }
+
+  def getShard(id: ShardId) = withTransaction(_.getShard(id))
+  def shardsForHostname(hostname: String) = withTransaction(_.shardsForHostname(hostname))
+  def listShards() = withTransaction(_.listShards())
+  def getBusyShards() = withTransaction(_.getBusyShards())
+
+  def addLink(upId: ShardId, downId: ShardId, weight: Int) {
+    withTransaction(_.addLink(upId, downId, weight))
+  }
+
+  def removeLink(upId: ShardId, downId: ShardId) {
+    withTransaction(_.removeLink(upId, downId))
+  }
+
+  def listUpwardLinks(id: ShardId) = withTransaction(_.listUpwardLinks(id))
+
+  def listDownwardLinks(id: ShardId) = withTransaction(_.listDownwardLinks(id))
+  def listLinks() = withTransaction(_.listLinks())
+
+  def setForwarding(forwarding: Forwarding) { withTransaction(_.setForwarding(forwarding)) }
+  def removeForwarding(forwarding: Forwarding) { withTransaction(_.removeForwarding(forwarding)) }
+  def replaceForwarding(oldId: ShardId, newId: ShardId) {
+    withTransaction(_.replaceForwarding(oldId, newId))
+  }
+
+  def getForwarding(tableId: Int, baseId: Long) = withTransaction(_.getForwarding(tableId, baseId))
+  def getForwardingForShard(id: ShardId) = withTransaction(_.getForwardingForShard(id))
+  def getForwardings() = withTransaction(_.getForwardings())
+  def getForwardingsForTableIds(tableIds: Seq[Int]) = withTransaction(_.getForwardingsForTableIds(tableIds))
+
+  def listHostnames() = withTransaction(_.listHostnames())
+  def listTables() = withTransaction(_.listTables())
+
+  def getUpdateVersion() = withTransaction(_.getUpdateVersion())
+  def incrementVersion() { withTransaction(_.incrementVersion()) }
+
+  def batchExecute(commands : Seq[BatchedCommand]) { withTransaction(_.batchExecute(commands)) }
 
   // Forwardings/Shard Management Read Methods
 
@@ -207,7 +373,7 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
     val deletedForwardings = mutable.Map[(Int,Long), Forwarding]()
 
     queryEvaluator.select("SELECT * FROM forwardings WHERE updated_seq > ?", updatedSequence) { row =>
-      val f  = rowToForwarding(row)
+      val f  = SqlShard.rowToForwarding(row)
       val fs = if (row.getBoolean("deleted")) deletedForwardings else newForwardings
 
       fs += (f.tableId, f.baseId) -> f
@@ -257,107 +423,6 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
 
       _currentState
     }
-  }
-
-  // Version methods
-  def getUpdateVersion() : Long = {
-    val query = "SELECT counter FROM update_counters WHERE id = 'version'"
-    queryEvaluator.selectOne(query)(_.getLong("counter")).getOrElse(0L)
-  }
-
-  def incrementVersion() {
-    queryEvaluator.execute(
-      "INSERT INTO update_counters (id, counter) VALUES ('version', 1) ON DUPLICATE KEY UPDATE counter = counter + 1")
-  }
-
-  def getShard(id: ShardId) = {
-    val query = "SELECT * FROM shards WHERE hostname = ? AND table_prefix = ?"
-    queryEvaluator.selectOne(query, id.hostname, id.tablePrefix)(rowToShardInfo) getOrElse {
-      throw new NonExistentShard("Shard not found: %s".format(id))
-    }
-  }
-
-  def listTables() = {
-    queryEvaluator.select("SELECT DISTINCT table_id FROM forwardings")(_.getInt("table_id")).toList.sortWith((a,b) => a < b)
-  }
-
-  def listHostnames() = {
-    queryEvaluator.select("SELECT DISTINCT hostname FROM shards")(_.getString("hostname")).toList
-  }
-
-  def listLinks() = {
-    queryEvaluator.select("SELECT * FROM shard_children ORDER BY parent_hostname, parent_table_prefix")(rowToLinkInfo).toList
-  }
-
-  def listDownwardLinks(id: ShardId) = {
-    val query = "SELECT * FROM shard_children WHERE parent_hostname = ? AND parent_table_prefix = ? ORDER BY weight DESC"
-    queryEvaluator.select(query, id.hostname, id.tablePrefix)(rowToLinkInfo).toList
-  }
-
-  def listUpwardLinks(id: ShardId) = {
-    val query = "SELECT * FROM shard_children WHERE child_hostname = ? AND child_table_prefix = ? ORDER BY weight DESC"
-    queryEvaluator.select(query, id.hostname, id.tablePrefix)(rowToLinkInfo).toList
-  }
-
-  def listShards() = {
-    queryEvaluator.select("SELECT * FROM shards")(rowToShardInfo).toList
-  }
-
-  def markShardBusy(id: ShardId, busy: Busy.Value) {
-    val query = "UPDATE shards SET busy = ? WHERE hostname = ? AND table_prefix = ?"
-    if (queryEvaluator.execute(query, busy.id, id.hostname, id.tablePrefix) == 0) {
-      throw new NonExistentShard("Could not find shard: %s".format(id))
-    }
-  }
-
-  def getForwarding(tableId: Int, baseId: Long) = {
-    val query = "SELECT * FROM forwardings WHERE base_source_id = ? AND table_id = ? AND deleted = 0"
-    queryEvaluator.selectOne(query, baseId, tableId)(rowToForwarding) getOrElse { throw new ShardException("No such forwarding") }
-  }
-
-  def getForwardingForShard(id: ShardId) = {
-    val query = "SELECT * FROM forwardings WHERE shard_hostname = ? AND shard_table_prefix = ? AND deleted = 0"
-    queryEvaluator.selectOne(query, id.hostname, id.tablePrefix)(rowToForwarding) getOrElse { throw new ShardException("No such forwarding") }
-  }
-
-  def getForwardings() = {
-    queryEvaluator.select("SELECT * FROM forwardings WHERE deleted = 0 ORDER BY table_id, base_source_id ASC")(rowToForwarding).toList
-  }
-
-  def getForwardingsForTableIds(tableIds: Seq[Int]) = {
-    queryEvaluator.select("SELECT * FROM forwardings WHERE table_id IN (?) AND deleted = 0 ORDER BY table_id, base_source_id ASC", tableIds)(rowToForwarding).toList
-  }
-
-  def shardsForHostname(hostname: String) = {
-    queryEvaluator.select("SELECT * FROM shards WHERE hostname = ?", hostname)(rowToShardInfo).toList
-  }
-
-  def getBusyShards() = {
-    queryEvaluator.select("SELECT * FROM shards where busy != 0")(rowToShardInfo).toList
-  }
-
-  def reload() {
-    try {
-      synchronized {
-        _currentState         = null
-        _forwardingUpdatedSeq = 0L
-      }
-
-      List("shards", "shard_children", "forwardings", "update_counters", "hosts").foreach { table =>
-        queryEvaluator.select("DESCRIBE " + table) { row => }
-      }
-    } catch {
-      case e: SQLException =>
-        // try creating the schema
-        rebuildSchema()
-    }
-  }
-
-  def rebuildSchema() {
-    queryEvaluator.execute(SqlShard.SHARDS_DDL)
-    queryEvaluator.execute(SqlShard.SHARD_CHILDREN_DDL)
-    queryEvaluator.execute(SqlShard.FORWARDINGS_DDL)
-    queryEvaluator.execute(SqlShard.UPDATE_COUNTER_DDL)
   }
 }
 

--- a/src/main/scala/com/twitter/gizzard/nameserver/SqlShard.scala
+++ b/src/main/scala/com/twitter/gizzard/nameserver/SqlShard.scala
@@ -343,7 +343,7 @@ class SqlShardManagerSource(queryEvaluator: QueryEvaluator) extends ShardManager
         _forwardingUpdatedSeq = 0L
       }
 
-      List("shards", "shard_children", "forwardings", "update_counters", "hosts, version").foreach { table =>
+      List("shards", "shard_children", "forwardings", "update_counters", "hosts").foreach { table =>
         queryEvaluator.select("DESCRIBE " + table) { row => }
       }
     } catch {

--- a/src/main/scala/com/twitter/gizzard/thrift/ManagerService.scala
+++ b/src/main/scala/com/twitter/gizzard/thrift/ManagerService.scala
@@ -12,6 +12,7 @@ import com.twitter.gizzard.thrift.conversions.Forwarding._
 import com.twitter.gizzard.thrift.conversions.Host._
 import com.twitter.gizzard.shards._
 import com.twitter.gizzard.scheduler._
+import com.twitter.gizzard.nameserver
 import com.twitter.gizzard.nameserver._
 import com.twitter.logging.Logger
 
@@ -121,6 +122,10 @@ extends Manager.Iface {
 
   def diff_shards(shardIds: JList[ShardId]) = {
     wrapEx(adminJobManager.scheduleDiffJob(shardIds.toList.map(_.asInstanceOf[ShardId].fromThrift)))
+  }
+
+  def batch_execute(commands : JList[BatchedCommand]) {
+    wrapEx(shardManager.batchExecute(commands.map(nameserver.BatchedCommand.apply)))
   }
 
   // Job Scheduler Management

--- a/src/main/scala/com/twitter/gizzard/thrift/ManagerService.scala
+++ b/src/main/scala/com/twitter/gizzard/thrift/ManagerService.scala
@@ -128,6 +128,18 @@ extends Manager.Iface {
     wrapEx(shardManager.batchExecute(commands.map(nameserver.BatchedCommand.apply)))
   }
 
+  def increment_state_version() {
+    wrapEx(shardManager.incrementStateVersion())
+  }
+
+  def get_current_state_version() : Long = {
+    wrapEx(shardManager.getCurrentStateVersion())
+  }
+
+  def get_master_state_version() : Long = {
+    wrapEx(shardManager.getMasterStateVersion())
+  }
+
   // Job Scheduler Management
 
   def retry_errors()  = wrapEx(scheduler.retryErrors())

--- a/src/main/thrift/Manager.thrift
+++ b/src/main/thrift/Manager.thrift
@@ -114,6 +114,27 @@ service Manager {
 
   list<i32> list_tables() throws(1: GizzardException ex)
 
+  // versioning
+
+  /**
+   * Increment the "master" version number of the nameserver state.
+   * This method is called implicitly after any successful update of nameserver state,
+   * so it's unlikely that you'll need to call this method directly.
+   * Does not trigger a local reload.
+   */
+  void increment_state_version() throws(1: GizzardException ex)
+
+  /**
+   * Get this application's current view of the state version.
+   */
+  i64 get_current_state_version() throws(1: GizzardException ex)
+
+  /**
+   * Get the master version number of the nameserver state according to the shard manager.
+   * The master version may be ahead of this application's version.
+   */
+  i64 get_master_state_version() throws(1: GizzardException ex)
+
   void batch_execute(1: list<BatchedCommand> commands) throws (1: GizzardException ex)
 
   list<NameServerState> dump_nameserver(1: list<i32> table_id) throws(1: GizzardException ex)

--- a/src/main/thrift/Manager.thrift
+++ b/src/main/thrift/Manager.thrift
@@ -55,6 +55,26 @@ struct Host {
   4: HostStatus status
 }
 
+struct AddLinkRequest {
+  1: required ShardId up_id
+  2: required ShardId down_id
+  3: required i32 weight
+}
+
+struct RemoveLinkRequest {
+  1: required ShardId up_id
+  2: required ShardId down_id
+}
+
+union BatchedCommand {
+  1: optional ShardInfo create_shard
+  2: optional ShardId delete_shard
+  3: optional AddLinkRequest add_link
+  4: optional RemoveLinkRequest remove_link
+  5: optional Forwarding set_forwarding
+  6: optional Forwarding remove_forwarding
+}
+
 service Manager {
   void reload_updated_forwardings() throws(1: GizzardException ex)
   void reload_config() throws(1: GizzardException ex)
@@ -93,6 +113,8 @@ service Manager {
   void diff_shards(1: list<ShardId> ids) throws(1: GizzardException ex)
 
   list<i32> list_tables() throws(1: GizzardException ex)
+
+  void batch_execute(1: list<BatchedCommand> commands) throws (1: GizzardException ex)
 
   list<NameServerState> dump_nameserver(1: list<i32> table_id) throws(1: GizzardException ex)
 

--- a/src/test/scala/com/twitter/gizzard/nameserver/MemoryShardSpec.scala
+++ b/src/test/scala/com/twitter/gizzard/nameserver/MemoryShardSpec.scala
@@ -138,6 +138,15 @@ class MemoryShardSpec extends ConfiguredSpecification with JMocker with ClassMoc
       }
     }
 
+    "manage update version" in {
+      nsShard.getUpdateVersion() mustEqual 0L
+      nsShard.incrementVersion()
+      nsShard.getUpdateVersion() mustEqual 1L
+      nsShard.incrementVersion()
+      nsShard.incrementVersion()
+      nsShard.getUpdateVersion() mustEqual 3L
+    }
+
     "advanced shard navigation" in {
       val shard1 = new ShardInfo(SQL_SHARD, "forward_1", "localhost")
       val shard2 = new ShardInfo(SQL_SHARD, "forward_1_also", "localhost")

--- a/src/test/scala/com/twitter/gizzard/nameserver/MemoryShardSpec.scala
+++ b/src/test/scala/com/twitter/gizzard/nameserver/MemoryShardSpec.scala
@@ -139,12 +139,15 @@ class MemoryShardSpec extends ConfiguredSpecification with JMocker with ClassMoc
     }
 
     "manage update version" in {
-      nsShard.getUpdateVersion() mustEqual 0L
-      nsShard.incrementVersion()
-      nsShard.getUpdateVersion() mustEqual 1L
-      nsShard.incrementVersion()
-      nsShard.incrementVersion()
-      nsShard.getUpdateVersion() mustEqual 3L
+      nsShard.getMasterStateVersion() mustEqual 0L
+      nsShard.getCurrentStateVersion() mustEqual 0L
+      nsShard.incrementStateVersion()
+      nsShard.getMasterStateVersion() mustEqual 1L
+      nsShard.getCurrentStateVersion() mustEqual 1L
+      nsShard.incrementStateVersion()
+      nsShard.incrementStateVersion()
+      nsShard.getMasterStateVersion() mustEqual 3L
+      nsShard.getCurrentStateVersion() mustEqual 3L
     }
 
     "advanced shard navigation" in {

--- a/src/test/scala/com/twitter/gizzard/nameserver/PollingUpdaterSpec.scala
+++ b/src/test/scala/com/twitter/gizzard/nameserver/PollingUpdaterSpec.scala
@@ -16,7 +16,8 @@ class PollingUpdaterSpec extends ConfiguredSpecification with JMocker with Class
       val shard = mock[ShardManagerSource]
       val nameServer = new NameServer(LeafRoutingNode(shard), identity)
       expect {
-        atLeast(2).of(shard).getUpdateVersion()
+        atLeast(1).of(shard).getCurrentStateVersion() willReturn (0L)
+        atLeast(1).of(shard).getMasterStateVersion() willReturn (0L)
       }
       val pollingUpdater = new PollingUpdater(nameServer, 1.second)
       pollingUpdater.start()
@@ -28,7 +29,8 @@ class PollingUpdaterSpec extends ConfiguredSpecification with JMocker with Class
       val shard = mock[ShardManagerSource]
       val nameServer = new NameServer(LeafRoutingNode(shard), identity)
       expect {
-        exactly(4).of(shard).getUpdateVersion() willReturnEach (0L, 1L, 1L, 5L)
+        exactly(4).of(shard).getCurrentStateVersion() willReturnEach (0L, 0L, 2L, 2L)
+        exactly(4).of(shard).getMasterStateVersion() willReturnEach (0L, 2L, 2L, 5L)
         exactly(2).of(shard).reload
         exactly(2).of(shard).currentState willReturn (List[NameServerState]())
       }
@@ -44,7 +46,8 @@ class PollingUpdaterSpec extends ConfiguredSpecification with JMocker with Class
       val shard = mock[ShardManagerSource]
       val nameServer = new NameServer(LeafRoutingNode(shard), identity)
       expect {
-        exactly(1).of(shard).getUpdateVersion() willReturnEach (0L)
+        exactly(1).of(shard).getCurrentStateVersion() willReturnEach (10L)
+        exactly(1).of(shard).getMasterStateVersion() willReturnEach (10L)
       }
 
       val pollingUpdater = new PollingUpdater(nameServer, 1.second)

--- a/src/test/scala/com/twitter/gizzard/nameserver/PollingUpdaterSpec.scala
+++ b/src/test/scala/com/twitter/gizzard/nameserver/PollingUpdaterSpec.scala
@@ -1,0 +1,54 @@
+package com.twitter.gizzard.nameserver
+
+import com.twitter.util.Duration
+import com.twitter.conversions.time._
+import com.twitter.gizzard.shards._
+import com.twitter.gizzard.thrift.conversions.ShardInfo._
+import com.twitter.gizzard.test.NameServerDatabase
+import com.twitter.gizzard.ConfiguredSpecification
+import org.specs.Specification
+import org.specs.mock.{ClassMocker, JMocker}
+import java.util.concurrent.TimeUnit
+
+class PollingUpdaterSpec extends ConfiguredSpecification with JMocker with ClassMocker with NameServerDatabase {
+  "PollingUpdater" should {
+    "Start, poll, and stop" in {
+      val shard = mock[ShardManagerSource]
+      val nameServer = new NameServer(LeafRoutingNode(shard), identity)
+      expect {
+        atLeast(2).of(shard).getUpdateVersion()
+      }
+      val pollingUpdater = new PollingUpdater(nameServer, 1.second)
+      pollingUpdater.start()
+      Thread.sleep(200)
+      pollingUpdater.stop()
+    }
+
+    "Reload on version change" in {
+      val shard = mock[ShardManagerSource]
+      val nameServer = new NameServer(LeafRoutingNode(shard), identity)
+      expect {
+        exactly(4).of(shard).getUpdateVersion() willReturnEach (0L, 1L, 1L, 5L)
+        exactly(2).of(shard).reload
+        exactly(2).of(shard).currentState willReturn (List[NameServerState]())
+      }
+
+      val pollingUpdater = new PollingUpdater(nameServer, 1.second)
+      pollingUpdater.poll()
+      pollingUpdater.poll()
+      pollingUpdater.poll()
+      pollingUpdater.poll()
+    }
+
+    "Not reload when there is no version change" in {
+      val shard = mock[ShardManagerSource]
+      val nameServer = new NameServer(LeafRoutingNode(shard), identity)
+      expect {
+        exactly(1).of(shard).getUpdateVersion() willReturnEach (0L)
+      }
+
+      val pollingUpdater = new PollingUpdater(nameServer, 1.second)
+      pollingUpdater.poll()
+    }
+  }
+}

--- a/src/test/scala/com/twitter/gizzard/nameserver/SqlShardSpec.scala
+++ b/src/test/scala/com/twitter/gizzard/nameserver/SqlShardSpec.scala
@@ -329,6 +329,15 @@ class SqlShardSpec extends ConfiguredSpecification with JMocker with ClassMocker
       }
     }
 
+    "manage update version" in {
+      nsShard.getUpdateVersion() mustEqual 0L
+      nsShard.incrementVersion()
+      nsShard.getUpdateVersion() mustEqual 1L
+      nsShard.incrementVersion()
+      nsShard.incrementVersion()
+      nsShard.getUpdateVersion() mustEqual 3L
+    }
+
     "advanced shard navigation" in {
       val shard1 = new ShardInfo(SQL_SHARD, "forward_1", "localhost")
       val shard2 = new ShardInfo(SQL_SHARD, "forward_1_also", "localhost")


### PR DESCRIPTION
An API to execute a batch of commands as an atomic unit.
Also tracks a nameserver state version, which is updated on any state change.

union BatchedCommand {
  1: optional ShardInfo create_shard
  2: optional ShardId delete_shard
  3: optional AddLinkRequest add_link
  4: optional RemoveLinkRequest remove_link
  5: optional Forwarding set_forwarding
  6: optional Forwarding remove_forwarding
}

service Manager {
...
  void batch_execute(1: list<BatchedCommand> commands) throws (1: GizzardException ex)
...
  void increment_state_version() throws(1: GizzardException ex)
  i64 get_current_state_version() throws(1: GizzardException ex)
  i64 get_master_state_version() throws(1: GizzardException ex)
...
}
