### PR TITLE
expose bad-job-count metric

### DIFF
--- a/src/main/scala/com/twitter/gizzard/scheduler/JobScheduler.scala
+++ b/src/main/scala/com/twitter/gizzard/scheduler/JobScheduler.scala
@@ -167,7 +167,7 @@ extends Process with JobConsumer {
             job.errorMessage = e.toString
             if (job.errorCount > errorLimit) {
               badJobQueue.put(job)
-              Stats.incr("bad-job-count")
+              Stats.incr("job-bad-count")
             } else {
               errorQueue.put(job)
             }


### PR DESCRIPTION
Trivial change to expose 'bad-job-count' metric so that interested parties could put alerts on it. Normally there should be no bad jobs but there is we must know it in a timely manner. Having the metric exposed can help us achieve this.
